### PR TITLE
Missing Required Field Returns No Error

### DIFF
--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1,0 +1,27 @@
+package requests
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type RequiredTest struct {
+	X string `request:",required"`
+	Y string `request:"y"`
+}
+
+func Test_Required_Returns_Error_When_Missing(t *testing.T) {
+	body := bytes.NewBufferString(`{"y":"bar"}`)
+	httpRequest, err := http.NewRequest("POST", "/", body)
+	require.NoError(t, err)
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	request := New(httpRequest)
+	target := new(RequiredTest)
+
+	assert.Error(t, request.Unmarshal(target))
+}


### PR DESCRIPTION
**Expected Result**
When a struct field has a `request=",required"` tag, it errors when unmarshalling.

**Actual Result**
No error.
